### PR TITLE
Replace Shout with a new module SecureShell

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Socket",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueSocket",
-        "state": {
-          "branch": null,
-          "revision": "c46a3d41f5b2401d18bcb46d0101cdc5cd13e307",
-          "version": "1.0.52"
-        }
-      },
-      {
         "package": "Environment",
         "repositoryURL": "https://github.com/wlisac/environment.git",
         "state": {
@@ -26,15 +17,6 @@
           "branch": null,
           "revision": "142d4bc1118602f3679c777d2e0da89c227cd918",
           "version": "1.2.0"
-        }
-      },
-      {
-        "package": "Shout",
-        "repositoryURL": "https://github.com/jakeheis/Shout",
-        "state": {
-          "branch": null,
-          "revision": "65bf1d1d42e2fb0c47e4d78c0653ebb6d5de5cb5",
-          "version": "0.5.6"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,18 +14,28 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
         .package(url: "https://github.com/mxcl/Path.swift.git", from: "1.0.0"),
         .package(name: "Environment", url: "https://github.com/wlisac/environment.git", from: "0.11.1"),
-        .package(url: "https://github.com/jakeheis/Shout", from: "0.5.5"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .systemLibrary(
+            name: "Clibssh",
+            pkgConfig: "libssh",
+            providers: [
+                .brew(["libssh"])
+            ]
+        ),
+        .target(
+            name: "SecureShell",
+            dependencies: ["Clibssh"]
+        ),
         .target(
             name: "gitlab-fusion",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Environment", package: "Environment"),
                 .product(name: "Path", package: "Path.swift"),
-                .product(name: "Shout", package: "Shout"),
+                .target(name: "SecureShell"),
             ]
         ),
     ]

--- a/Sources/Clibssh/module.modulemap
+++ b/Sources/Clibssh/module.modulemap
@@ -1,0 +1,11 @@
+//
+//  module.modulemap
+//  Clibssh
+//
+//  Created by Ryan Lovelett on 10/5/20.
+//
+
+module Clibssh {
+    header "shim.h"
+    export *
+}

--- a/Sources/Clibssh/shim.h
+++ b/Sources/Clibssh/shim.h
@@ -1,0 +1,13 @@
+//
+//  Header.h
+//  Clibssh
+//
+//  Created by Ryan Lovelett on 10/5/20.
+//
+
+#ifndef C_LIB_SSH_h
+#define C_LIB_SSH_h
+#include <libssh/libssh.h>
+#include <libssh/callbacks.h>
+
+#endif /* C_LIB_SSH_h */

--- a/Sources/SecureShell/Channel.swift
+++ b/Sources/SecureShell/Channel.swift
@@ -1,0 +1,153 @@
+//
+//  Channel.swift
+//  SecureShell
+//
+//  Created by Ryan Lovelett on 10/5/20.
+//
+
+import Clibssh
+import Foundation
+
+/// A `Channel` represents a sub-process of a single `Session`.
+///
+/// More precisely, a `Channel` wraps `libssh`'s `ssh_channel` struct and
+/// manages the lifecycle of that struct. Additionally it provides Swift native
+/// wrapper helpers for a subset of the available `libssh` C APIs.
+public final class Channel {
+    /// Reference to the `libssh` channel structure.
+    private let channel: ssh_channel
+
+    /// Pointer to the first element in channel read buffer.
+    private let channelReadBufferPointer: UnsafeMutableRawPointer
+
+    /// A data buffer to store read bytes from the channel.
+    private let channelReadBuffer: UnsafeMutablePointer<CChar>
+
+    /// The read buffer is 4x the memory page size. 4 is an arbitrary choice.
+    private let bufferSize = 4 * sysconf(_SC_PAGESIZE)
+
+    /// This enum is meant to give a human readable name to the magic numbers
+    /// of `0` and `1` that can be given to `libssh` read methods:
+    /// `ssh_channel_read`, `ssh_channel_read_timeout`,
+    /// `ssh_channel_read_nonblocking`.
+    private enum Stream: CInt {
+        case stdout = 0
+        case stderr = 1
+    }
+
+    /// Allocate and open a channel suited for a shell, not TCP forwarding, for
+    /// a given `Session`.
+    ///
+    /// - Parameter session: The session to open the channel in.
+    /// - Throws: If the channel cannot be allocated or opened.
+    init(_ session: ssh_session) throws {
+        // Allocate a `ssh_channel`
+        guard let channel = ssh_channel_new(session) else {
+            throw SecureShellError(session, description: "A ssh_channel could not be allocated.")
+        }
+
+        // Open a session channel to run a shell command
+        let returnCode = ssh_channel_open_session(channel)
+        guard returnCode == SSH_OK else {
+            // Must cleanup because `deinit` is not called when failable
+            // initializers fail. Go figure.
+            // https://www.jessesquires.com/blog/2020/10/08/swift-deinit-is-not-called-for-failable-initializers/
+            ssh_channel_free(channel)
+            throw SecureShellError(session, description: "The channel could not open a session.")
+        }
+        self.channel = channel
+
+        channelReadBuffer = UnsafeMutablePointer<CChar>.allocate(capacity: Int(bufferSize))
+        channelReadBufferPointer = UnsafeMutableRawPointer(channelReadBuffer)
+    }
+
+    deinit {
+        channelReadBuffer.deallocate()
+        ssh_channel_close(channel)
+        ssh_channel_free(channel)
+    }
+
+    /// Check if remote has sent an EOF.
+    /// - Returns: `false` if there is no EOF. `true` otherwise.
+    private var isEOF: Bool {
+        let eof = ssh_channel_is_eof(channel)
+        return (eof == 0) ? false : true
+    }
+
+    /// Check if the channel is open or not.
+    /// - Returns: `false` if the channel is closed. `true` otherwise.
+    private var isOpen: Bool {
+        let open = ssh_channel_is_open(channel)
+        return (open == 0) ? false : true
+    }
+
+    /// Check if the channel is closed or not.
+    /// - Returns: `false` if the channel is opened. `true` otherwise.
+    private var isClosed: Bool {
+        let closed = ssh_channel_is_closed(channel)
+        return (closed == 0) ? false : true
+    }
+
+    /// Get the exit status of the channel. This is the equivalent of the error
+    /// code from the executed instruction.
+    private var exitCode: CInt {
+        ssh_channel_get_exit_status(channel)
+    }
+
+    /// Read data from either the standard stream (stdout) or an error stream
+    /// (stderr).
+    ///
+    /// - Parameter stream: The stream to attempt to read data from.
+    /// - Returns: `Data` if a 1 or more bytes are returned from the selected
+    /// stream. If there is an error or no bytes are returned from stream then
+    /// the method returns `nil`.
+    private func read(stream: Stream = .stdout) -> Data? {
+        let returnCode = ssh_channel_read_timeout(
+            channel,
+            channelReadBufferPointer,
+            UInt32(bufferSize),
+            stream.rawValue,
+            250
+        )
+
+        guard returnCode != SSH_ERROR else {
+            fatalError("Reading from \(stream)")
+        }
+
+        if returnCode > 0 {
+            return Data(bytes: channelReadBufferPointer, count: Int(returnCode))
+        }
+
+        return nil
+    }
+
+    /// Run a shell command without an interactive shell.
+    ///
+    /// - Note: This is similar to `sh -c command`.
+    /// - Parameters:
+    ///   - command: Command to execute on the remote.
+    ///   - stdout: File descriptor to write the data from the remote standard stream.
+    ///   - stderr: File descriptor to write the data from the remote error stream.
+    /// - Returns: Error code from the executed instruction.
+    public func execute(_ command: String, stdout: FileHandle? = nil, stderr: FileHandle? = nil) -> CInt {
+        let returnCode = command.withCString {
+            ssh_channel_request_exec(channel, $0)
+        }
+
+        guard returnCode == SSH_OK else {
+            fatalError("The channel could not execute the command: \(command)")
+        }
+
+        while isOpen && !isEOF {
+            if let buffer = read(stream: .stdout) {
+                stdout?.write(buffer)
+            }
+
+            if let buffer = read(stream: .stderr) {
+                stdout?.write(buffer)
+            }
+        }
+
+        return exitCode
+    }
+}

--- a/Sources/SecureShell/Logging.swift
+++ b/Sources/SecureShell/Logging.swift
@@ -1,0 +1,36 @@
+//
+//  Logging.swift
+//  SecureShell
+//
+//  Created by Ryan Lovelett on 10/9/20.
+//
+
+import Clibssh
+import os.log
+
+let log = OSLog(subsystem: "me.lovelett.gitlab-fusion", category: "SecureShell")
+
+/// Handle logging messages provided by libssh.
+///
+/// - Parameters:
+///   - priority: Priority of the log, the smaller being the more important.
+///   - function: The function name calling the the logging fucntions.
+///   - buffer: The actual message.
+///   - userdata: Userdata to be passed to the callback function.
+func sshLoggingCallback(priority: Int32, function: UnsafePointer<CChar>?, buffer: UnsafePointer<CChar>?, userdata: UnsafeMutableRawPointer?) {
+    let message = buffer.map { String(cString: $0) } ?? ""
+    switch priority {
+    case SSH_LOG_WARN:
+        // Show only warnings
+        os_log("%{public}@", log: log, type: .error, message)
+    case SSH_LOG_INFO:
+        // Get some information what's going on
+        os_log("%{public}@", log: log, type: .info, message)
+    case SSH_LOG_DEBUG, SSH_LOG_TRACE:
+        // Get detailed debuging information
+        // Get trace output, packet information,
+        os_log("%{public}@", log: log, type: .debug, message)
+    default:
+        os_log("%{public}@", log: log, type: .default, message)
+    }
+}

--- a/Sources/SecureShell/SecureShellError.swift
+++ b/Sources/SecureShell/SecureShellError.swift
@@ -1,0 +1,48 @@
+//
+//  SecureShellError.swift
+//  SecureShell
+//
+//  Created by Ryan Lovelett on 10/5/20.
+//
+
+import Clibssh
+import Foundation
+
+/// Capture error text from libssh and provide them in a idiomatic Swift
+/// structure.
+struct SecureShellError: LocalizedError {
+    /// The error text from the last error.
+    let libsshErrorText: String
+
+    /// A description provided in addition to the libssh error text.
+    let description: String
+
+    /// Initialize a new error without libssh error text.
+    ///
+    /// - Parameter description: An error with no libssh text.
+    init(_ description: String) {
+        self.description = description
+        self.libsshErrorText = ""
+    }
+
+    /// Initialize a new error from a session and proving context description.
+    ///
+    /// - Parameter session: Attempt to extract error text from this session.
+    /// - Parameter description: A description provided in addition to the libssh error text.
+    init(_ session: ssh_session, description: String) {
+        self.init(UnsafeMutableRawPointer(session), description)
+    }
+
+    /// Initialize a new error from a session and proving context description.
+    ///
+    /// - Parameter session: Attempt to extract error text from this session.
+    /// - Parameter description: A description provided in addition to the libssh error text.
+    private init(_ session: UnsafeMutableRawPointer, _ description: String) {
+        self.description = description
+        if let error = ssh_get_error(session) {
+            libsshErrorText = String(cString: error)
+        } else {
+            libsshErrorText = "Was not able to infer the error from \(session)."
+        }
+    }
+}

--- a/Sources/SecureShell/Session.swift
+++ b/Sources/SecureShell/Session.swift
@@ -1,0 +1,130 @@
+//
+//  Session.swift
+//  SecureShell
+//
+//  Created by Ryan Lovelett on 10/5/20.
+//
+
+import Clibssh
+
+/// A `Session` encapsulates the entire lifetime of the connection with a remote
+/// machine. A `Session` is responsible for connecting and authenticating the
+/// server and the user.
+public final class Session {
+    /// A reference to the libssh session
+    private let session: ssh_session
+
+    /// Create a new session.
+    ///
+    /// - Warning: This may currently be unsafe to call multiple times because
+    /// of the `ssh_set_log_callback`. Never really tested that.
+    /// - Parameters:
+    ///   - host: The hostname or ip address to connect to.
+    ///   - port: The port to connect to.
+    ///   - username: The username for authentication.
+    /// - Throws: `SecureShellError` if the session cannot be initialized.
+    public init(host: String, port: UInt32 = 22, username: String) throws {
+        ssh_set_log_callback(sshLoggingCallback)
+
+        // Allocate a new `ssh_session`
+        guard let newSession = ssh_new() else {
+            throw SecureShellError("A ssh_session could not be allocated.")
+        }
+        session = newSession
+
+        do {
+            try set(host, for: SSH_OPTIONS_HOST, on: session)
+            try set(port, for: SSH_OPTIONS_PORT, on: session)
+            try set(SSH_LOG_DEBUG, for: SSH_OPTIONS_LOG_VERBOSITY, on: session)
+            try set(username, for: SSH_OPTIONS_USER, on: session)
+            try SecureShell.connect(using: session)
+        } catch {
+            // Must cleanup because `deinit` is not called when failable
+            // initializers fail. Go figure.
+            // https://www.jessesquires.com/blog/2020/10/08/swift-deinit-is-not-called-for-failable-initializers/
+            ssh_free(session)
+            throw error
+        }
+    }
+
+    deinit {
+        ssh_disconnect(session)
+        ssh_free(session)
+    }
+
+    /// Attempt to authenticate the session using password.
+    ///
+    /// - Parameter password: The password to attempt authentication with.
+    /// - Throws: `SecureShellError` if authentication fails.
+    public func authenticate(withPassword password: String) throws {
+        let returnCode = password.withCString {
+            ssh_auth_e(rawValue: ssh_userauth_password(session, nil, $0))
+        }
+
+        guard returnCode == SSH_AUTH_SUCCESS else {
+            throw SecureShellError(session, description: "Could not authenticate.")
+        }
+    }
+
+    /// Create a new `Channel` in the current session.
+    /// - Throws: If the `Channel` could not be created.
+    /// - Returns: A new `Channel` in the current session.
+    public func openChannel() throws -> Channel {
+        try Channel(session)
+    }
+}
+
+// MARK:- Idiomatic Swift wrappers around libssh C functions
+
+/// Set options on the SSH session.
+///
+/// This is a wrapper around `ssh_options_set` to allow more idiomatic Swift
+/// interaction with the libssh function.
+///
+/// - Note: See `ssh_options_set` for documentation on all the available options.
+/// - Parameters:
+///   - string: The value to set for the specified option.
+///   - option: The option type to set. See `ssh_options_set` for documentation
+///   of available options.
+///   - session: The allocated SSH session to set the option on.
+/// - Throws: If the option could not be set.
+private func set<Value>(_ value: Value, for option: ssh_options_e, on session: ssh_session) throws {
+    let returnValue = withUnsafePointer(to: value) {
+        ssh_options_set(session, option, $0)
+    }
+    guard returnValue == SSH_OK else {
+        throw SecureShellError(session, description: "Unable to set \(value) for \(option)")
+    }
+}
+
+/// Set options on the SSH session.
+///
+/// This is a wrapper around `ssh_options_set` to allow more idiomatic Swift
+/// interaction with the libssh function.
+///
+/// - Note: See `ssh_options_set` for documentation on all the available options.
+/// - Parameters:
+///   - string: The value to set for the specified option.
+///   - option: The option type to set. See `ssh_options_set` for documentation
+///   of available options.
+///   - session: The allocated SSH session to set the option on.
+/// - Throws: If the option could not be set.
+private func set(_ string: String, for option: ssh_options_e, on session: ssh_session) throws {
+    let returnValue = string.withCString {
+        ssh_options_set(session, option, $0)
+    }
+    guard returnValue == SSH_OK else {
+        throw SecureShellError(session, description: "Unable to set \(string) for \(option)")
+    }
+}
+
+/// Attempt to connect to the remote SSH server.
+///
+/// - Parameter session: The SSH session to connect.
+/// - Throws: `SecureShellError` if authentication fails.
+private func connect(using session: ssh_session) throws {
+    let returnValue = ssh_connect(session)
+    guard returnValue == SSH_OK else {
+        throw SecureShellError(session, description: "Unable to connect to session")
+    }
+}

--- a/Sources/gitlab-fusion/Stages/Run.swift
+++ b/Sources/gitlab-fusion/Stages/Run.swift
@@ -10,7 +10,7 @@ import Environment
 import Foundation
 import os.log
 import Path
-import Shout
+import SecureShell
 
 private let log = OSLog(subsystem: subsystem, category: "run")
 
@@ -84,11 +84,10 @@ struct Run: ParsableCommand {
         let script = try String(contentsOf: scriptFile)
         os_log("Running script:\n%{public}@", log: log, type: .info, script)
 
-        let ssh = try SSH(host: ip)
-        try ssh.authenticate(username: sshUsername, password: sshPassword)
-        let exitCode = try ssh.execute(script) { output in
-            print(output)
-        }
+        let session = try Session(host: ip, username: sshUsername)
+        try session.authenticate(withPassword: sshPassword)
+        let channel = try session.openChannel()
+        let exitCode = channel.execute(script, stdout: FileHandle.standardOutput, stderr: FileHandle.standardError)
 
         if exitCode == 0 {
             os_log("Run stage %{public}@ returned %{public}d.", log: log, type: .info, subStage, exitCode)


### PR DESCRIPTION
This change fixes a few issues in the project:

1. Shout has some odd compliation issues as noted in https://github.com/jakeheis/Shout/issues/34
2. Shout is based on libssh2 and libssh2 does not support [certificate based authentication](https://github.com/libssh2/libssh2/issues/289).
3. Shout did not capture standard error from remote.

This patch creates 2 new modules. `Clibssh` and `SecureShell`. `Clibssh` is a system package that imports libssh into Swift. `Clibssh` is not expected to be used directly. `SecureShell` wraps `Clibssh` and provides the API that is expected to be used by `gitlab-fusion`.

Fixes #1 