### PR TITLE
Add waiting for ip

### DIFF
--- a/Sources/gitlab-fusion/Stages/Prepare.swift
+++ b/Sources/gitlab-fusion/Stages/Prepare.swift
@@ -131,6 +131,17 @@ struct Prepare: ParsableCommand {
         try clone.start(hasGUI: isGUI)
 
         FileHandle.standardOutput.write(line: "Waiting for guest \"\(clonedGuestName)\" to become responsive...")
+        // Wait for ip to become available
+        for _ in 1...60 {
+            if let _ = clone.ip {
+                break
+            }
+
+            sleep(60)
+        }
+
+        // TODO: Actually handle this case better
+        // 'Waited 60x60 seconds for ip to become available, exiting...'
         guard let ip = clone.ip else {
             throw GitlabRunnerError.systemFailure
         }


### PR DESCRIPTION
This PR fixes that runner is failing if ip is not available yet (guest needs some time to boot).

Same wait & retry logic as for ssh