### PR TITLE
Output the correct exit code from VMware failures

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.1"),
         .package(url: "https://github.com/mxcl/Path.swift.git", from: "1.0.0"),
         .package(name: "Environment", url: "https://github.com/wlisac/environment.git", from: "0.11.1"),
     ],

--- a/Sources/gitlab-fusion/Extensions/ErrorCode.swift
+++ b/Sources/gitlab-fusion/Extensions/ErrorCode.swift
@@ -1,0 +1,14 @@
+//
+//  ErrorCode.swift
+//  gitlab-fusion
+//
+//  Created by Ryan Lovelett on 4/9/20.
+//
+
+import ArgumentParser
+
+extension ArgumentParser.ExitCode {
+    init(_ error: GitlabRunnerError) {
+        self.init(error.exitCode)
+    }
+}

--- a/Sources/gitlab-fusion/Stages/Cleanup.swift
+++ b/Sources/gitlab-fusion/Stages/Cleanup.swift
@@ -58,6 +58,11 @@ struct Cleanup: ParsableCommand {
         os_log("The cloned VMware Fusion guest is %{public}@", log: log, type: .info, clonedGuestPath.string)
         let clone = VirtualMachine(image: clonedGuestPath, executable: options.vmwareFusion)
 
-        try clone.stop()
+        do {
+            try clone.stop()
+        } catch {
+            os_log("Could not stop the VMware Fusion guest.", log: log, type: .error)
+            throw ExitCode(GitlabRunnerError.systemFailure)
+        }
     }
 }

--- a/Sources/gitlab-fusion/Stages/Config.swift
+++ b/Sources/gitlab-fusion/Stages/Config.swift
@@ -72,17 +72,22 @@ struct Config: ParsableCommand {
             driver: driver
         )
 
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let json = try encoder.encode(config)
+        do {
+            let encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let json = try encoder.encode(config)
 
-        if let string = String(data: json, encoding: .utf8) {
-            os_log("%{public}@", log: log, type: .info, string)
-        } else {
-            os_log("The encoded data was not a valid UTF-8 string.", log: log, type: .error)
+            if let string = String(data: json, encoding: .utf8) {
+                os_log("%{public}@", log: log, type: .info, string)
+            } else {
+                os_log("The encoded data was not a valid UTF-8 string.", log: log, type: .error)
+            }
+
+            FileHandle.standardOutput.write(json)
+        } catch {
+            os_log("Could not encode JSON data.", log: log, type: .error)
+            throw ExitCode(GitlabRunnerError.systemFailure)
         }
-
-        FileHandle.standardOutput.write(json)
     }
 }

--- a/Sources/gitlab-fusion/Stages/Prepare.swift
+++ b/Sources/gitlab-fusion/Stages/Prepare.swift
@@ -132,7 +132,8 @@ struct Prepare: ParsableCommand {
 
         FileHandle.standardOutput.write(line: "Waiting for guest \"\(clonedGuestName)\" to become responsive...")
         guard let ip = clone.ip else {
-            throw GitlabRunnerError.systemFailure
+            os_log("VMware Guest never resolved an IP address.", log: log, type: .error)
+            throw ExitCode(GitlabRunnerError.systemFailure)
         }
 
         // Wait for ssh to become available
@@ -152,6 +153,7 @@ struct Prepare: ParsableCommand {
 
         // TODO: Actually handle this case better
         // 'Waited 60 seconds for sshd to start, exiting...'
-        throw GitlabRunnerError.systemFailure
+        os_log("VMware Guest never responded to SSH requests.", log: log, type: .error)
+        throw ExitCode(GitlabRunnerError.systemFailure)
     }
 }

--- a/Sources/gitlab-fusion/Stages/Run.swift
+++ b/Sources/gitlab-fusion/Stages/Run.swift
@@ -76,7 +76,8 @@ struct Run: ParsableCommand {
         let clone = VirtualMachine(image: clonedGuestPath, executable: options.vmwareFusion)
 
         guard let ip = clone.ip else {
-            throw GitlabRunnerError.systemFailure
+            os_log("VMware Guest never resolved an IP address.", log: log, type: .error)
+            throw ExitCode(GitlabRunnerError.systemFailure)
         }
 
         let script = try String(contentsOf: scriptFile)
@@ -91,7 +92,7 @@ struct Run: ParsableCommand {
             os_log("Run stage %{public}@ returned %{public}d.", log: log, type: .info, subStage, exitCode)
         } else {
             os_log("Run stage %{public}@ returned %{public}d.", log: log, type: .error, subStage, exitCode)
-            throw GitlabRunnerError.buildFailure
+            throw ExitCode(GitlabRunnerError.buildFailure)
         }
     }
 }


### PR DESCRIPTION
There were situations were it was returning `GitlabRunnerError.buildFailure` when it should have been returning `GitlabRunnerError.systemFailure`.